### PR TITLE
Moved the registering of Modules to register()

### DIFF
--- a/src/LaravelModulesServiceProvider.php
+++ b/src/LaravelModulesServiceProvider.php
@@ -23,8 +23,6 @@ class LaravelModulesServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->registerNamespaces();
-
-        $this->registerModules();
     }
 
     /**
@@ -43,6 +41,7 @@ class LaravelModulesServiceProvider extends ServiceProvider
         $this->registerServices();
         $this->setupStubPath();
         $this->registerProviders();
+        $this->registerModules();
     }
 
     /**


### PR DESCRIPTION
Module service providers should be allows to register binding via register() at the same time as all over service providers. This doesn't change the timing of the boot() functionality.